### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.1.4] - 2025-11-12
+
+### Features
+
+- *(TUI)* Added ability to move files.
+- *(TUI)* Added delete feature
 ## [0.2.0] - 2025-11-12
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filessh"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-lock",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filessh"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "A fast and convenient TUI file browser for remote servers "
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `filessh`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4] - 2025-11-12

### Features

- *(TUI)* Added ability to move files.
- *(TUI)* Added delete feature
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).