### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.1.7] - 2025-11-13
+
+### Features
+
+- *(TUI)* Changed Metadata pane, to include all metadata attributes in a nicer Table
+- *(TUI)* Fixed effect timing
+
+### Bug Fixes
+
+- *(typo)* Fixed a type in the keybinds
+- *(bug)* Fixed state not resetting after directory download
+
+### Documentation
+
+- *(README)* Added features subsection to readme
 ## [0.1.6] - 2025-11-13
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filessh"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-lock",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filessh"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "A fast and convenient TUI file browser for remote servers "
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `filessh`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7] - 2025-11-13

### Features

- *(TUI)* Changed Metadata pane, to include all metadata attributes in a nicer Table
- *(TUI)* Fixed effect timing

### Bug Fixes

- *(typo)* Fixed a type in the keybinds
- *(bug)* Fixed state not resetting after directory download

### Documentation

- *(README)* Added features subsection to readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).