### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.8] - 2025-11-14
+
+### Features
+
+- *(TUI)* Added the ability to create files
+
+### Bug Fixes
+
+- *(clippy)* Removed `unwrap()`s and replaced with error propogation
+
+### Documentation
+
+- *(changelog)* Changed CHANGELOG format to include title
 ## [0.1.7] - 2025-11-13
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filessh"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-lock",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filessh"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "A fast and convenient TUI file browser for remote servers "
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `filessh`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8] - 2025-11-14

### Features

- *(TUI)* Added the ability to create files

### Bug Fixes

- *(clippy)* Removed `unwrap()`s and replaced with error propogation

### Documentation

- *(changelog)* Changed CHANGELOG format to include title
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).