### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [0.1.9] - 2025-11-14
+
+### Documentation
+
+- Update the README to include license information and added the relevant license files.
+
 ## [0.1.8] - 2025-11-14
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filessh"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-lock",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filessh"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "A fast and convenient TUI file browser for remote servers "
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `filessh`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9] - 2025-11-14

### Documentation

- Update the README to include license information and added the relevant license files.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).