### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## [0.2.0] - 2025-11-19
+
+### Features
+
+- Added clap-completion support
+- *(cli)* [**breaking**] Changed the CLI structure to be modular and enable subcommands like install-man-pages
+- *(docs)* Added man pages for the project and the config system
+- Added a config system to the project, allowing users to configure themes
+
 ## [0.1.10] - 2025-11-17
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filessh"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "async-lock",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filessh"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2024"
 description = "A fast and convenient TUI file browser for remote servers "
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `filessh`: 0.1.10 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0] - 2025-11-19

### Features

- Added clap-completion support
- *(cli)* [**breaking**] Changed the CLI structure to be modular and enable subcommands like install-man-pages
- *(docs)* Added man pages for the project and the config system
- Added a config system to the project, allowing users to configure themes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).