### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [0.2.2] - 2025-11-22
+
+### Features
+
+- *(errors)* Added better error handling using panic-hooks and human-panic
+
+### Miscellaneous Tasks
+
+- Typo fixed
+
 ## [0.2.1] - 2025-11-19
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filessh"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filessh"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "A fast and convenient TUI file browser for remote servers "
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `filessh`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2] - 2025-11-22

### Features

- *(errors)* Added better error handling using panic-hooks and human-panic

### Miscellaneous Tasks

- Typo fixed
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).