### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+## [0.3.0] - 2025-11-24
+
+### Features
+
+- *(TUI)* Added support for filtering out hidden files
+
+### Refactor
+
+- *(state)* [**breaking**] Refactored MainUI's get_file_entries to be `CoW` to support hidden files filering
+
+### Styling
+
+- *(file view)* Differentiated between directories and files using colour
+
 ## [0.2.2] - 2025-11-22
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filessh"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filessh"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 description = "A fast and convenient TUI file browser for remote servers "
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `filessh`: 0.2.2 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0] - 2025-11-24

### Features

- *(TUI)* Added support for filtering out hidden files

### Refactor

- *(state)* [**breaking**] Refactored MainUI's get_file_entries to be `CoW` to support hidden files filering

### Styling

- *(file view)* Differentiated between directories and files using colour
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).