### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [unreleased]
 
+## [0.3.3] - 2025-12-06
+
+### Styling
+
+- *(CHANGELOG)* Revamped Changelog style
+
 ### Features
 - *(config)* Added a default config generator and fixed config detection (by @JayanAXHF)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filessh"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filessh"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 description = "A fast and convenient TUI file browser for remote servers "
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `filessh`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3] - 2025-12-06

### Styling

- *(CHANGELOG)* Revamped Changelog style

### Features
- *(config)* Added a default config generator and fixed config detection (by @JayanAXHF)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).