### PR TITLE
resolve clippy warnings

### DIFF
--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -2,10 +2,9 @@
 //! to allow for the buils.rs script to
 //! generate the man pages and completions
 //! for the CLI at build time.
-use clap::Parser;
-use clap::command;
 use clap::crate_authors;
 use std::path::PathBuf;
+use clap::Parser;
 
 use std::sync::LazyLock;
 

--- a/src/ssh_config/de.rs
+++ b/src/ssh_config/de.rs
@@ -216,7 +216,7 @@ impl<'de> Deserializer<'de> {
     }
 }
 
-impl<'de, 'a> serde::Deserializer<'de> for &'a mut Deserializer<'de> {
+impl<'de> serde::Deserializer<'de> for & mut Deserializer<'de> {
     type Error = ParserError;
 
     fn deserialize_any<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
@@ -527,7 +527,7 @@ impl<'a, 'de> MapAccess<'de> for WhitespaceSeparated<'a, 'de> {
         K: serde::de::DeserializeSeed<'de>,
     {
         // If we have a pending host name (from the "Host" line), inject it into the map
-        if let Some(_) = self.de.pending_host {
+        if self.de.pending_host.is_some() {
             // The Host struct has a field renamed to "Host", so we inject that key
             return seed.deserialize("Host".into_deserializer()).map(Some);
         }

--- a/src/ssh_config/reader.rs
+++ b/src/ssh_config/reader.rs
@@ -18,7 +18,7 @@ const SSH_CONFIG_PATHS: LazyLock<[String; 1]> = LazyLock::new(|| {
 });
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-const SSH_CONFIG_PATH: LazyLock<[String; 1]> = LazyLock::new(|| {
+static SSH_CONFIG_PATH: LazyLock<[String; 1]> = LazyLock::new(|| {
     let mut path = std::env::var("HOME").unwrap();
     path.push_str(r#"/.ssh/config"#);
     [path]


### PR DESCRIPTION
Make the named constant SSH_CONFIG_PATH static due to interior mutability. Remove redundant pattern matching. Elide a needless lifetime.